### PR TITLE
Fix misspellings identified by `typos`

### DIFF
--- a/_posts/2020-04-02-parallel-task-execution.md
+++ b/_posts/2020-04-02-parallel-task-execution.md
@@ -74,11 +74,11 @@ The goal would be to process the list of tasks in _topological order_; however d
 
 A non-parallel topological walk may result in `d -> b -> c -> a` which would take 4 _units_.
 
-However if we were to optimize the processing it would be posssible to do it
+However if we were to optimize the processing it would be possible to do it
 in `[d, c] -> [b] -> [a]`; 3 _units_.
 
 Topological sort is well understood[^1], however I was not able to find online
-a succint code snippet for doing so in parallel.
+a succinct code snippet for doing so in parallel.
 
 {::nomarkdown}
 <div style="clear: both"/>
@@ -98,7 +98,7 @@ executor = construct an executor service
 # unless the grap you are using is thread safe
 mutex = construct mutex
 
-mutex.sychronize do
+mutex.synchronize do
     # keep looping until the graph is empty
     until graph.empty?
         # sinks are nodes whose outdegree is 0;
@@ -111,7 +111,7 @@ mutex.sychronize do
             executor.submit do
                 # run the task!
                 task.run
-                mutex.sychronize do
+                mutex.synchronize do
                     # remove this task from the graph
                     graph.remove_node sink
                 end

--- a/_posts/2020-07-20-packaging-a-maven-application-with-nix.md
+++ b/_posts/2020-07-20-packaging-a-maven-application-with-nix.md
@@ -49,7 +49,7 @@ mkDerivation {
     buildInputs = [ jdk11_headless maven ];
     src = ./.;
     buildPhase = ''
-      while mvn package -Dmaven.repo.local=$out/.m2 -Dmaven.wagon.rto=5000; [ $? = 1 ]; do
+      while mvn package -Dmaven.repo.local=$out/.m2 -Dmaven.wagon.to=5000; [ $? = 1 ]; do
         echo "timeout, restart maven to continue downloading"
       done
     '';

--- a/_posts/2020-11-10-isolation-using-java-s-classloader.md
+++ b/_posts/2020-11-10-isolation-using-java-s-classloader.md
@@ -155,4 +155,4 @@ Ultimately, we used _ClassLoader_ as a way to create **isolation** between the c
 
 For this to work though, we must have used an _interface_ (Dog) otherwise there would be no way to perform the casting to the _Rottweiler_ implementation, since that would need to be resolved at compile time!
 
-You can do a lot of fancier stuff with _ClassLoaders_, such as even creating classes dynamically at runtime. Wow! I'll leave that as a follow-up excercise :)
+You can do a lot of fancier stuff with _ClassLoaders_, such as even creating classes dynamically at runtime. Wow! I'll leave that as a follow-up exercise :)

--- a/_posts/2020-11-12-debugging-a-jnr-ffi-bug-in-nix.md
+++ b/_posts/2020-11-12-debugging-a-jnr-ffi-bug-in-nix.md
@@ -7,7 +7,7 @@ excerpt_separator: <!--more-->
 
 > This is a write-up of an issue I discovered when using more advanced features of Java within a Nix environment. Please refer to the GitHub issue [#103493](https://github.com/NixOS/nixpkgs/issues/103493) to see any ongoing process
 
-I have been onboarding several engineers to doing their development workflow using Nix; promising all the benefits of hermeticity & reproducibility. The biggest challenge is making sure that onboarding continues to be _seemless_.
+I have been onboarding several engineers to doing their development workflow using Nix; promising all the benefits of hermeticity & reproducibility. The biggest challenge is making sure that onboarding continues to be _seamless_.
 
 Therefore it's 🚨 *all hands on deck* when someone has encountered a SIGSEGV; especially since the environment is within the JVM.
 ```bash

--- a/_posts/2021-08-12-a-nix-binary-cache-specification.md
+++ b/_posts/2021-08-12-a-nix-binary-cache-specification.md
@@ -108,7 +108,7 @@ Cool 😎! Looks like we computed the correct hash for the _FileHash_.
 > This is needed to shrink the necessary space to work within the POSIX filepath limits.
 > Frustratingly, [sha256sum](https://linux.die.net/man/1/sha256sum) doesn't have a base32 option.
 
-The NAR hash should be calcuated in a very similar fashion.
+The NAR hash should be calculated in a very similar fashion.
 
 Let's try by piping it into [unxz](https://linux.die.net/man/1/unxz).
 

--- a/_posts/2021-09-10-using-an-overlay-filesystem-to-improve-nix-ci-builds.md
+++ b/_posts/2021-09-10-using-an-overlay-filesystem-to-improve-nix-ci-builds.md
@@ -26,7 +26,7 @@ This was an interesting choice for a few reasons:
 
 We decided to seek out alternatives where we can remove the prebuild _/nix/store_ from the container but still reduce the cold-boot cost for CI jobs.
 
-The **caveat** to the solution we seeked is that the Docker image still **installed** Nix which meant it created a _/nix/store_ entry and the necessary _~/.nix_profile_ symlinks.
+The **caveat** to the solution we sought is that the Docker image still **installed** Nix which meant it created a _/nix/store_ entry and the necessary _~/.nix_profile_ symlinks.
 
 > [Overlayfs](https://github.com/torvalds/linux/commit/e9be9d5e76e34872f0c37d72e25bc27fe9e2c54c) allows one, usually read-write, directory tree to be
 overlaid onto another, read-only directory tree.  All modifications

--- a/_posts/2022-03-14-shrinkwrap-taming-dynamic-shared-objects.md
+++ b/_posts/2022-03-14-shrinkwrap-taming-dynamic-shared-objects.md
@@ -44,7 +44,7 @@ $ ldd /nix/store/vvxcs4f8x14gyahw50ssff3sk2dij2b3-emacs-27.2/bin/.emacs-27.2-wra
 103
 ```
 
-💡 When faced with a recurring problem, often the solution is to cache the previous answer to avoid unecessary work.
+💡 When faced with a recurring problem, often the solution is to cache the previous answer to avoid unnecessary work.
 
 Shrinkwrap adopts this approach by freezing the required dependencies directly into the `DT_NEEDED` section of the binary by having it point to an absolute path. The
 transitive dependency list is also lifted to the top-level binary to simplify auditing the required dependencies.
@@ -77,7 +77,7 @@ $ patchelf --print-needed emacs_stamped
 ```
 
 Applying Shrinkwrap resulted in a large reduction in syscalls, which equates to a **36x speedup**. The absolute amount
-recovered may seem negligible however this unecessary penalty is paid on every process invocation, and on every machine executing the binary.
+recovered may seem negligible however this unnecessary penalty is paid on every process invocation, and on every machine executing the binary.
 
 | Program      | Calls(stat/openat)     | Time (Seconds) |
 | :---:           | :---:               | :---:          |
@@ -96,7 +96,7 @@ Shrinkwrap relies on the ability for a dynamic linker to deduplicate libraries w
 
 Nothing in Shrinkwrap assumes any Nix specifics and it may also be integrated into other store-like systems as well such as Guix and Spack.
 
-It is not yet integrated into Nixpkgs but I woud love feedback. 😊
+It is not yet integrated into Nixpkgs but I would love feedback. 😊
 
 ## Philosophical Questions
 

--- a/_posts/2022-09-12-making-runpath-redundant-for-nix.md
+++ b/_posts/2022-09-12-making-runpath-redundant-for-nix.md
@@ -32,7 +32,7 @@ Can systems like Nix do more to solve this problem?
 Nix and similar systems have the benefit of knowing ahead of time the exact path for every dependency. They are also particularly well positioned to make deep impactful changes because they rebuild the world __bottom up__, starting from libc.
 
 
-Although these systems are radical departures from traditional Linux distributions and try to rebel against the Filesystem Hierachy Standard, they nevertheless rely on fundamental tooling and control knobs such as _RUNPATH_ to bandaid over the solution.
+Although these systems are radical departures from traditional Linux distributions and try to rebel against the Filesystem Hierarchy Standard, they nevertheless rely on fundamental tooling and control knobs such as _RUNPATH_ to bandaid over the solution.
 
 🧐 Let's make the use of _RUNPATH_ in Nix obsolete and unnecessary.
 
@@ -42,7 +42,7 @@ We can do this through the observation that GCC will propagate the _soname_ stor
 Here is a small example to demonstrate
 ```
 # Let's build our library with an absolute path for soname
-# notice I have set the soname to an absoulte path
+# notice I have set the soname to an absolute path
 ❯ gcc -shared -o libf.so -Wl,-soname,/nix/store/znxycsxlnx2s9zn6g0s0fl4z57ar7aps-libf-0.1/lib/libf.so -x c - <<EOF
         #include <stdio.h>
         void f() { puts("hello world"); }

--- a/_posts/2023-09-11-quick-insights-using-sqlelf.md
+++ b/_posts/2023-09-11-quick-insights-using-sqlelf.md
@@ -27,7 +27,7 @@ A typical question someone may ask themselves though is:
 
 __Which library that I load is providing _function foo_?__
 
-This is a worthwhile question because you would like to know which shared object is not only providing the symbol definition but also which the linker (`ld.so`) choses
+This is a worthwhile question because you would like to know which shared object is not only providing the symbol definition but also which the linker (`ld.so`) chooses
 to link against at runtime.
 
 The _state of the art_ (prior to sqlelf) of how to retrieve this diagnostic information is using `LD_DEBUG` environment variable and trolling through the large dump of logs it emits. 🤦
@@ -100,7 +100,7 @@ LIMIT 10"
 
 The reality of `LD_DEBUG` however is that it usefulness came in knowing the _final resolution_ of a given symbol.
 
-ELF files are free to have and export any symbols and often times, wether by accident (benign) or maliciously, the same symbol may be exported by
+ELF files are free to have and export any symbols and often times, whether by accident (benign) or maliciously, the same symbol may be exported by
 multiple libraries.
 
 > This is what empowers tools such as `LD_PRELOAD` so that users can take over symbols such as `malloc` and replace them with alternative strategies.
@@ -141,7 +141,7 @@ HAVING count(*) >= 2"
 │    name    │   version   │ symbol_count │                                libraries                                │
 │ __finite   │ GLIBC_2.2.5 │ 2            │ /usr/lib/x86_64-linux-gnu/libm.so.6:/usr/lib/x86_64-linux-gnu/libc.so.6 │
 │ __finitef  │ GLIBC_2.2.5 │ 2            │ /usr/lib/x86_64-linux-gnu/libm.so.6:/usr/lib/x86_64-linux-gnu/libc.so.6 │
-│ __finitel  │ GLIBC_2.2.5 │ 2            │ /usr/lib/x86_64-linux-gnu/libm.so.6:/usr/lib/x86_64-linux-gnu/libc.so.6 │
+│ __finite  │ GLIBC_2.2.5 │ 2            │ /usr/lib/x86_64-linux-gnu/libm.so.6:/usr/lib/x86_64-linux-gnu/libc.so.6 │
 │ __signbit  │ GLIBC_2.2.5 │ 2            │ /usr/lib/x86_64-linux-gnu/libm.so.6:/usr/lib/x86_64-linux-gnu/libc.so.6 │
 │ __signbitf │ GLIBC_2.2.5 │ 2            │ /usr/lib/x86_64-linux-gnu/libm.so.6:/usr/lib/x86_64-linux-gnu/libc.so.6 │
 │ __signbitl │ GLIBC_2.2.5 │ 2            │ /usr/lib/x86_64-linux-gnu/libm.so.6:/usr/lib/x86_64-linux-gnu/libc.so.6 │
@@ -150,7 +150,7 @@ HAVING count(*) >= 2"
 │ copysignl  │ GLIBC_2.2.5 │ 2            │ /usr/lib/x86_64-linux-gnu/libm.so.6:/usr/lib/x86_64-linux-gnu/libc.so.6 │
 │ finite     │ GLIBC_2.2.5 │ 2            │ /usr/lib/x86_64-linux-gnu/libm.so.6:/usr/lib/x86_64-linux-gnu/libc.so.6 │
 │ finitef    │ GLIBC_2.2.5 │ 2            │ /usr/lib/x86_64-linux-gnu/libm.so.6:/usr/lib/x86_64-linux-gnu/libc.so.6 │
-│ finitel    │ GLIBC_2.2.5 │ 2            │ /usr/lib/x86_64-linux-gnu/libm.so.6:/usr/lib/x86_64-linux-gnu/libc.so.6 │
+│ finite    │ GLIBC_2.2.5 │ 2            │ /usr/lib/x86_64-linux-gnu/libm.so.6:/usr/lib/x86_64-linux-gnu/libc.so.6 │
 │ frexp      │ GLIBC_2.2.5 │ 2            │ /usr/lib/x86_64-linux-gnu/libm.so.6:/usr/lib/x86_64-linux-gnu/libc.so.6 │
 │ frexpf     │ GLIBC_2.2.5 │ 2            │ /usr/lib/x86_64-linux-gnu/libm.so.6:/usr/lib/x86_64-linux-gnu/libc.so.6 │
 │ frexpl     │ GLIBC_2.2.5 │ 2            │ /usr/lib/x86_64-linux-gnu/libm.so.6:/usr/lib/x86_64-linux-gnu/libc.so.6 │

--- a/_posts/2024-05-03-speeding-up-elf-relocations-for-store-based-systems.md
+++ b/_posts/2024-05-03-speeding-up-elf-relocations-for-store-based-systems.md
@@ -64,12 +64,12 @@ If we inspect the resulting executable file with _readelf_ we can see the reloca
 ```console
 ❯ readelf -r main
 ...
-Relocation section '.rela.plt' at offset 0x530 contains 5 entries:
+Relocation section '.real.plt' at offset 0x530 contains 5 entries:
   Offset          Info           Type           Sym. Value    Sym. Name + Addend
 000000004000  000600000007 R_X86_64_JUMP_SLO 0000000000000000 foo + 0
 ```
 
-There are various types of relocation structures (REL vs. RELA) and types (R_X86_64_JUMP_SLOT, R_X86_64_GLOB_DAT, etc.) that can be present in an ELF file.
+There are various types of relocation structures (REL vs. REAL) and types (R_X86_64_JUMP_SLOT, R_X86_64_GLOB_DAT, etc.) that can be present in an ELF file.
 I am concerned about JUMP_SLOT relocations, which are used to resolve function calls to shared libraries.
 
 ### Why Is Symbol Resolution Necessary?
@@ -145,7 +145,7 @@ To achieve this improvement, I have a basic implementation built atop musl's dyn
       size_t st_value;
       // Offset of the relocation
       size_t offset;
-      // Aboslute path of the DSO where symbol was found
+      // Absolute path of the DSO where symbol was found
       char symbol_dso_name[255];
       // Name of the DSO that needs the relocation
       char dso_name[255];

--- a/_posts/2024-07-10-nix-remote-building-with-yubikey.md
+++ b/_posts/2024-07-10-nix-remote-building-with-yubikey.md
@@ -13,7 +13,7 @@ I'm leaving my tiny module that I'm using to enable my Framework Laptop running 
 
 <!--more-->
 
-### Prequisites
+### Prerequisites
 
 1. Using a Yubikey for SSH access
 

--- a/_posts/2024-07-17-fish-the-bash-way.md
+++ b/_posts/2024-07-17-fish-the-bash-way.md
@@ -64,7 +64,7 @@ Now when you start your shell, via an interactive session, it will automatically
 
 **AND**
 
-Your `$SHELL` remains bash, which means that any non-interactive use by programs will get the common bash they unfortunately implicilty rely on.
+Your `$SHELL` remains bash, which means that any non-interactive use by programs will get the common bash they unfortunately implicitly rely on.
 
 ```console
 ❯ ps -p $fish_pid

--- a/_posts/2024-07-21-scaling-past-1-million-elf-symbol-relocations.md
+++ b/_posts/2024-07-21-scaling-past-1-million-elf-symbol-relocations.md
@@ -111,7 +111,7 @@ On a synthetic benchmark, creating 1000 shared objects each with 1000 symbols  f
 
 ![benchmark heatmap](/assets/images/benchmark_heatmap.png)
 
-A noticable speedup was seen in the established benchmark [pynamic](https://github.com/LLNL/pynamic). Pynamic is a benchmark written by Lawrence Livermore National Laboratory (LLNL) to simulate internal software written.
+A noticeable speedup was seen in the established benchmark [pynamic](https://github.com/LLNL/pynamic). Pynamic is a benchmark written by Lawrence Livermore National Laboratory (LLNL) to simulate internal software written.
 
 Similar to the prior synthetic benchmark, Pynamic creates an MPI application which starts an embedded Python interpreter and links it against a desired amount of Python modules.
 
@@ -119,7 +119,7 @@ Running the same configuration as outlined in [documentation](https://asc.llnl.g
 
 Finding real world applications beyond the software Pynamic itself may be emulating which contain 1_000_000+ symbol relocations proved challenging; but seeing the time needed to perform the relocations (26 seconds) it is understandable.
 
-Ulrich Drepper (long time glibc author) in fact devotes a large section of his guide on [How to Write Shared Libraries](https://www.cs.dartmouth.edu/~sergey/cs258/ABI/UlrichDrepper-How-To-Write-Shared-Libraries.pdf). Portions of the advice centers around shortening symbol names and being judicious about which symbols are exported to minimize the number of symbol relocations created. This optimziation technique eschews much of that advice and allows applications to scale beyond traditional limits and still appear relatively responsive in startup.
+Ulrich Drepper (long time glibc author) in fact devotes a large section of his guide on [How to Write Shared Libraries](https://www.cs.dartmouth.edu/~sergey/cs258/ABI/UlrichDrepper-How-To-Write-Shared-Libraries.pdf). Portions of the advice centers around shortening symbol names and being judicious about which symbols are exported to minimize the number of symbol relocations created. This optimization technique eschews much of that advice and allows applications to scale beyond traditional limits and still appear relatively responsive in startup.
 
 Similar to the [C10K](https://en.wikipedia.org/wiki/C10k_problem) problem faced in the earlier 2000s as the Linux kernel was attempting to scale to 10_000 connections; this work allows applications to think about scaling to 1 million symbol relocations.
 

--- a/_posts/2024-07-24-management-time.md
+++ b/_posts/2024-07-24-management-time.md
@@ -130,6 +130,6 @@ WHERE es.symbol_name IS NULL AND
 
 ℹ️ SQL is a powerful language to introspect binaries. Check out [sqlelf](https://github.com/fzakaria/sqlelf) for a more general utility. I have also published a paper on the benefits of using SQL to drive ELF analysis; [sqlelf: a SQL-centric Approach to ELF Analysis](https://arxiv.org/abs/2405.03883).
 
-I have only begun to scratch the surface of the possibilities of _management time_. Having memoized linking information frozen within something like the _/nix/store_ for every package availble within [nixpkgs](https://github.com/NixOS/nixpkgs) opens pretty imaginative workflows that no other distribution could compete with 🤯.
+I have only begun to scratch the surface of the possibilities of _management time_. Having memoized linking information frozen within something like the _/nix/store_ for every package available within [nixpkgs](https://github.com/NixOS/nixpkgs) opens pretty imaginative workflows that no other distribution could compete with 🤯.
 
 We've all taken the underpinnings of our toolchain for granted. It's true we are building on the shoulders of giants, but it's imperative to look back and rethink decisions that may have existed for decades especially in-light of newer development models (i.e. NixOS) that offer us a chance to radically deviate from pre-existing conventions.

--- a/_posts/2024-07-28-nixos-option-inspection.md
+++ b/_posts/2024-07-28-nixos-option-inspection.md
@@ -27,7 +27,7 @@ Imagine we have 3 modules: A, B & C
 
 ```nix
 # Module A
-# moudleA.nix
+# moduleA.nix
 {lib, ...}: {
   options = {
     a.value = lib.mkOption {

--- a/_posts/2024-07-29-import-but-don-t-import-your-nixos-modules.md
+++ b/_posts/2024-07-29-import-but-don-t-import-your-nixos-modules.md
@@ -24,7 +24,7 @@ In a [prior post]({% post_url 2024-07-28-nixos-option-inspection %}), I wrote ab
 
 Turns out, the answer in the post was _relatively simple_ and Nixpkgs has a gesture for discovering the answer via `definitionsWithLocations`.
 
-Turns out, in order to get `definitionsWithLocations` to play nice, you have to avoid a suprisingly common [footgun](https://notes.rmhogervorst.nl/post/2022/11/21/what-is-a-footgun/) 🥵.
+Turns out, in order to get `definitionsWithLocations` to play nice, you have to avoid a surprisingly common [footgun](https://notes.rmhogervorst.nl/post/2022/11/21/what-is-a-footgun/) 🥵.
 
 <!--more-->
 

--- a/_posts/2024-07-31-automatic-nix-flake-follows.md
+++ b/_posts/2024-07-31-automatic-nix-flake-follows.md
@@ -50,7 +50,7 @@ Here let's create our main top-level flake. You can think of this as your applic
 
 ```nix
 {
-  description = "Top Levle Flake";
+  description = "Top Level Flake";
 
   inputs = {
     a.url = path:./a;
@@ -103,7 +103,7 @@ We correcltly see at the start the two different versions of _nixpkgs_.
 }
 ```
 
-If we peek in our `flake.lock` file we see that `nixpkgs` is listed twice as an _inputs_ (`nixpkgs` & `nixpkgs_2`) and that they reference nodess that exist.
+If we peek in our `flake.lock` file we see that `nixpkgs` is listed twice as an _inputs_ (`nixpkgs` & `nixpkgs_2`) and that they reference nodes that exist.
 
 ```json
 {

--- a/_posts/2024-08-13-nixos-raspberry-pi-me.md
+++ b/_posts/2024-08-13-nixos-raspberry-pi-me.md
@@ -10,7 +10,7 @@ dust off my old Raspberry Pi 4, I looked to rebrand it as a new NixOS machine.
 
 Before I event went to play with my Pi, I was unhappy with my current home-networking setup and looked to give it a refresh.
 
-I have had always a positive experience with [Ubiquiti](https://www.ui.com/introduction) line of products. I installed two new AP (access points) and setup a _beautiful_ home rack server that is _completely unecessary_ since my Internet provider is Comcast with top upload speeds of 35 Mbps 🥲.
+I have had always a positive experience with [Ubiquiti](https://www.ui.com/introduction) line of products. I installed two new AP (access points) and setup a _beautiful_ home rack server that is _completely unnecessary_ since my Internet provider is Comcast with top upload speeds of 35 Mbps 🥲.
 
 <!--more-->
 
@@ -90,7 +90,7 @@ the following command which then copies the _/nix/store_ closure and activates t
     # Also don't use the vendored Linux kernel and just use the regular one.
     "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
     ../../modules/nix.nix
-    # Feedback from Matrix was to disable this and it's unecessary unless you are using
+    # Feedback from Matrix was to disable this and it's unnecessary unless you are using
     # some esoteric hardware.
     inputs.nixos-hardware.nixosModules.raspberry-pi-4
   ];

--- a/_posts/2024-08-29-bazel-overlay-pattern.md
+++ b/_posts/2024-08-29-bazel-overlay-pattern.md
@@ -29,7 +29,7 @@ _Sort of_. The `BUILD` files introduced into the registry either wrap the existi
 
 > I have created the project [bazel-overlay-example](https://github.com/fzakaria/bazel-overlay-example) that you can checkout on GitHub for reference.
 
-Let's run throgh a very minimal example to understand how this work.
+Let's run through a very minimal example to understand how this work.
 We have a C project, "hello_world", with a single file.
 
 ```

--- a/_posts/2024-09-26-bazel-knowledge-reproducible-outputs.md
+++ b/_posts/2024-09-26-bazel-knowledge-reproducible-outputs.md
@@ -15,7 +15,7 @@ Let's consider this simple action graph in Bazel.
 
 <!--more-->
 
-Bazel constructs an [action key](https://bazel.build/reference/glossary#action-cache) for each action which we can simplify down to consituting: the Starlark of the action itself & the SHA256 of the outputs of all the dependencies (i.e. srcs or deps).
+Bazel constructs an [action key](https://bazel.build/reference/glossary#action-cache) for each action which we can simplify down to constituting: the Starlark of the action itself & the SHA256 of the outputs of all the dependencies (i.e. srcs or deps).
 
 Let's consider a change to _File D_, which would mean that the action key for _Action C_ now differs.
 
@@ -125,6 +125,6 @@ override r-xr-xr-x fzakaria/wheel for bazel-bin/output.zip? y
 🙌  YES! As expected we now only re-run the _output_zip_ action and the final action
 can be skipped.
 
-We now have our graph reproducible in a way that can help Bazel give us incremental rebuilds by skipping portions of the grpah. 🥳
+We now have our graph reproducible in a way that can help Bazel give us incremental rebuilds by skipping portions of the graph. 🥳
 
 If reproducible builds interest you, I _highly_ recommend you check out the wealth of information on the subject by the [Reproducible Builds Group](https://reproducible-builds.org/docs/). They've documented all the various intricate ways they discovered software builds introduce nondeterminism into the build.


### PR DESCRIPTION
These were identified and fixed using version 1.21.0 of https://github.com/crate-ci/typos.