### PR TITLE
Fix Nix store chaining typo

### DIFF
--- a/_posts/2025-05-07-chaining-nix-stores-for-fun.md
+++ b/_posts/2025-05-07-chaining-nix-stores-for-fun.md
@@ -43,7 +43,7 @@ I now create a _second daemon_ that will listen on `/tmp/nix_socket_2` and whose
 
 ```console
 > NIX_DAEMON_SOCKET_PATH=/tmp/nix_socket_2 nix daemon \
-      --debug --store unix:///tmp/nix_socket_2
+      --debug --store unix:///tmp/nix_socket_1
 ```
 
 Now we can do our build!


### PR DESCRIPTION
The second Nix daemon's store should point to the first's socket.