### PR TITLE
Fix link to NpmNix parser in dynamic derivation post

### DIFF
--- a/_posts/2025-03-12-nix-dynamic-derivations-a-lang2nix-practicum.md
+++ b/_posts/2025-03-12-nix-dynamic-derivations-a-lang2nix-practicum.md
@@ -63,7 +63,7 @@ This `package.json` produces the following `package-lock.json` file.
 }
 ```
 
-[NpmNix](https://github.com/fzakaria/NpmNix) includes a very simple Golang parser, [parser.go](https://github.com/fzakaria/MakeNix/blob/main/parser/parser.go) (~70 lines of code), that parses the `package-lock.json` and generates the complete Nix expression.
+[NpmNix](https://github.com/fzakaria/NpmNix) includes a very simple Golang parser, [parser.go](https://github.com/fzakaria/NpmNix/blob/main/parser/parser.go) (~70 lines of code), that parses the `package-lock.json` and generates the complete Nix expression.
 
 Here is a sample of the Nix expression generated.
 


### PR DESCRIPTION
The link pointed to the parser of the previous post. Unbeknownst to me, the  Github code editor also added a newline at the end of the file. Oh well :)

Thanks for your blog, it's awesome!